### PR TITLE
Refactor primarily focused around API.js

### DIFF
--- a/classes/API.js
+++ b/classes/API.js
@@ -1,7 +1,7 @@
-﻿var request = require('request');
-var Swap = require('./swap.js');
-var input = require('./input.js');
-const url = require('url')
+﻿var request = require("request")
+var Swap = require("./swap.js")
+var input = require("./input.js")
+const url = require("url")
 
 /**
  * Sends a request to the given URL and calls the callback when it receives a response.
@@ -11,29 +11,29 @@ const url = require('url')
  * @param {Function} cb A callback function. This follows typical node conventions: The first argument will be an error (In this case, an error String) if one occurred, otherwise it will be undefined and the second argument will be the retrieved data.
  */
 function extractFromUrl(url, headers, cb) {
-    // Allows for omission of the 'headers' argument.
-    if (typeof headers === 'function') {
-        cb = headers;
-        headers = {};
+  // Allows for omission of the 'headers' argument.
+  if (typeof headers === "function") {
+    cb = headers
+    headers = {}
+  }
+
+  if (typeof headers !== "object") {
+    throw new TypeError("if headers are specified, they must be an object")
+  }
+
+  const options = { url, headers }
+  request(options, (error, response, body) => {
+    if (!error && response.statusCode === 200) {
+      return cb(undefined, error)
     }
 
-    if (typeof headers !== 'object') {
-        throw new TypeError('if headers are specified, they must be an object');
+    // TODO: Why is this try/catch here?
+    try {
+      return callback("error " + response.statusCode)
+    } catch (err) {
+      return callback("error " + err)
     }
-
-    const options = { url, headers };
-    request(options, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-            return cb(undefined, error);
-        }
-
-        // TODO: Why is this try/catch here?
-        try {
-            return callback("error " + response.statusCode);
-        } catch (err) {
-            return callback("error " + err);
-        }
-    })
+  })
 }
 
 /**
@@ -44,200 +44,259 @@ function extractFromUrl(url, headers, cb) {
  * @param {Function} cb A callback function. This follows typical node conventions: The first argument will be an error (In this case, an error String) if one occurred, otherwise it will be undefined and the second argument will be the retrieved data.
  */
 function makeRiotRequest(server, path, cb) {
-    const headers = {
-        'X-Riot-Token': process.env.RITO_KEY
-    };
+  const headers = {
+    "X-Riot-Token": process.env.RITO_KEY
+  }
 
-    const uri = url.format({
-        protocol: 'https',
-        hostname: `${server}.api.riotgames.com`,
-        path
-    });
+  const uri = url.format({
+    protocol: "https",
+    hostname: `${server}.api.riotgames.com`,
+    path
+  })
 
-    extractFromUrl(uri, headers, cb);
+  extractFromUrl(uri, headers, cb)
 }
 
 function URLmatchData(matchID) {
-    return `/lol/match/v3/matches/${matchID}`;
+  return `/lol/match/v3/matches/${matchID}`
 }
 
 function URLrecentGamesData(accountID) {
-    return `/lol/match/v3/matchlists/by-account/${accountID}/recent`;
+  return `/lol/match/v3/matchlists/by-account/${accountID}/recent`
 }
 
 function URLsummonerID(playerIGN) {
-    return `/lol/summoner/v3/summoners/by-name/${playerIGN}`;
+  return `/lol/summoner/v3/summoners/by-name/${playerIGN}`
 }
 
 function URLmasteryData(playerID) {
-    return `/lol/champion-mastery/v3/champion-masteries/by-summoner/${playerID}/by-champion/112`
+  return `/lol/champion-mastery/v3/champion-masteries/by-summoner/${playerID}/by-champion/112`
 }
 
 function URLliveGameData(playerID) {
-    return `/lol/spectator/v3/active-games/by-summoner/${playerID}`;
+  return `/lol/spectator/v3/active-games/by-summoner/${playerID}`
 }
 
 function playersRanksData(playerID) {
-    return `/lol/league/v3/positions/by-summoner/${playerID}`;
+  return `/lol/league/v3/positions/by-summoner/${playerID}`
 }
 
 function URLchampionData() {
-    return `/lol/static-data/v3/champions?dataById=true`;
+  return `/lol/static-data/v3/champions?dataById=true`
 }
 
 function URLgameTimeline(matchID) {
-    return `/lol/match/v3/timelines/by-match/${matchID}`;
+  return `/lol/match/v3/timelines/by-match/${matchID}`
 }
 
-exports.API = function () {
-    var api = this;
-    api.extractGameTimelineData = function (server, matchID, callback) {
-        makeRiotRequest(server, URLgameTimeline(matchID), (err, timelineAPI) => {
-            if (err)
-                return callback(`:warning: Error retrieving game timeline.`);
-            return callback(JSON.parse(timelineAPI));
-        });
-    };
-    api.extractPlayerRanksData = function (server, playerID, callback) {
-        makeRiotRequest(server, api.playersRanksData(playerID), (err, ranksAPI) => {
-            if (err)
-                return callback(`:warning: Error retrieving ranks data.`);
-            return callback(JSON.parse(ranksAPI));
-        });
-    };
-    api.extractMatchData = function (server, matchID, callback) {
-        makeRiotRequest(server, URLmatchData(matchID), (err, matchDataAPI) => {
-            if (err)
-                return callback(":warning: Error retrieving match data.");
-            return callback(JSON.parse(matchDataAPI));
-        });
-    };
-    api.extractRecentGamesData = function (server, accountID, callback) {
-        makeRiotRequest(server, URLrecentGamesData(accountID), (err, gameDataAPI) => {
-            if (err)
-                return callback(":warning: Error retrieving recent games data.");
-            return callback(JSON.parse(gamesDataAPI));
-        });
-    };
-    api.extractChampionData = function (server, callback) {
-        makeRiotRequest(server, URLchampionData(), (err, championDataAPI) => {
-            if (err)
-                return callback(":warning: Error retrieving champion data.");
-            return callback(JSON.parse(championDataAPI));
-        });
-    };
-    api.extractPlayersLiveGameData = function (server, playerID, callback) {
-        makeRiotRequest(server, URLliveGameData(playerID), (err, liveGameDataAPI) => {
-            if (err)
-                return callback(`:warning: This person either is not in game, or you did something wrong.`);
-            return callback(JSON.parse(liveGameDataAPI));
-        });
-    };
-    api.extractPlayerID = function (server, playerIGNAndServer, callback) {
-        makeRiotRequest(server, URLsummonerID(playerIGNAndServer[0]), (err, playerIDAPI) => {
-            if (err)
-                return callback(`:warning: Player ${decodeURIComponent(playerIGNAndServer[0]).toUpperCase()} doesn't exist.`);
-            return callback((JSON.parse(playerIDAPI)).id.toString());
-        });
-    };
-    api.extractPlayerAccountID = function (server, playerIGNAndServer, callback) {
-        makeRiotRequest(server, URLsummonerID(playerIGNAndServer[0]), (err, playerIDAPI) => {
-            if (err)
-                return callback(`:warning: Player ${decodeURIComponent(playerIGNAndServer[0]).toUpperCase()} doesn't exist.`);
-            return callback((JSON.parse(playerIDAPI)).accountId.toString());
-        });
-    };
-    api.extractPlayerMastery = function (server, playerID, callback) {
-        makeRiotRequest(server, URLmasteryData(playerID), (err, championMasteryDataAPI) => {
-            if (err)
-                return callback(`:warning: This person didn't play a single game of me. _Phew_.`);
+exports.API = function() {
+  var api = this
+  api.extractGameTimelineData = function(server, matchID, callback) {
+    makeRiotRequest(server, URLgameTimeline(matchID), (err, timelineAPI) => {
+      if (err) return callback(`:warning: Error retrieving game timeline.`)
+      return callback(JSON.parse(timelineAPI))
+    })
+  }
+  api.extractPlayerRanksData = function(server, playerID, callback) {
+    makeRiotRequest(server, api.playersRanksData(playerID), (err, ranksAPI) => {
+      if (err) return callback(`:warning: Error retrieving ranks data.`)
+      return callback(JSON.parse(ranksAPI))
+    })
+  }
+  api.extractMatchData = function(server, matchID, callback) {
+    makeRiotRequest(server, URLmatchData(matchID), (err, matchDataAPI) => {
+      if (err) return callback(":warning: Error retrieving match data.")
+      return callback(JSON.parse(matchDataAPI))
+    })
+  }
+  api.extractRecentGamesData = function(server, accountID, callback) {
+    makeRiotRequest(
+      server,
+      URLrecentGamesData(accountID),
+      (err, gameDataAPI) => {
+        if (err)
+          return callback(":warning: Error retrieving recent games data.")
+        return callback(JSON.parse(gamesDataAPI))
+      }
+    )
+  }
+  api.extractChampionData = function(server, callback) {
+    makeRiotRequest(server, URLchampionData(), (err, championDataAPI) => {
+      if (err) return callback(":warning: Error retrieving champion data.")
+      return callback(JSON.parse(championDataAPI))
+    })
+  }
+  api.extractPlayersLiveGameData = function(server, playerID, callback) {
+    makeRiotRequest(
+      server,
+      URLliveGameData(playerID),
+      (err, liveGameDataAPI) => {
+        if (err)
+          return callback(
+            `:warning: This person either is not in game, or you did something wrong.`
+          )
+        return callback(JSON.parse(liveGameDataAPI))
+      }
+    )
+  }
+  api.extractPlayerID = function(server, playerIGNAndServer, callback) {
+    makeRiotRequest(
+      server,
+      URLsummonerID(playerIGNAndServer[0]),
+      (err, playerIDAPI) => {
+        if (err)
+          return callback(
+            `:warning: Player ${decodeURIComponent(
+              playerIGNAndServer[0]
+            ).toUpperCase()} doesn't exist.`
+          )
+        return callback(JSON.parse(playerIDAPI).id.toString())
+      }
+    )
+  }
+  api.extractPlayerAccountID = function(server, playerIGNAndServer, callback) {
+    makeRiotRequest(
+      server,
+      URLsummonerID(playerIGNAndServer[0]),
+      (err, playerIDAPI) => {
+        if (err)
+          return callback(
+            `:warning: Player ${decodeURIComponent(
+              playerIGNAndServer[0]
+            ).toUpperCase()} doesn't exist.`
+          )
+        return callback(JSON.parse(playerIDAPI).accountId.toString())
+      }
+    )
+  }
+  api.extractPlayerMastery = function(server, playerID, callback) {
+    makeRiotRequest(
+      server,
+      URLmasteryData(playerID),
+      (err, championMasteryDataAPI) => {
+        if (err)
+          return callback(
+            `:warning: This person didn't play a single game of me. _Phew_.`
+          )
 
-            var mastery = JSON.parse(championMasteryDataAPI);
-            var chest = mastery.chestGranted;
-            var comment = ``;
+        var mastery = JSON.parse(championMasteryDataAPI)
+        var chest = mastery.chestGranted
+        var comment = ``
 
-            if (!chest) comment = `...how the hell you don't have a chest yet? <:vikwat:269523937669545987>`;
-            if (mastery.championLevel <= 4) comment = `...only level ${mastery.championLevel}? Come on. You need to step up your game.`;
-            if (mastery.championPoints >= "500000") comment = `Your dedication... is admirable.`;
-            if (mastery.championPoints >= "1000000") comment = `You're amongst the most loyal acolytes. You deserve a cookie. :cookie:`;
-            if (mastery.championPoints >= "100000" && mastery.championLevel < 6) comment = `Over 100k points and yet, still no level 7. _sighs heavily_`;
+        if (!chest)
+          comment = `...how the hell you don't have a chest yet? <:vikwat:269523937669545987>`
+        if (mastery.championLevel <= 4)
+          comment = `...only level ${
+            mastery.championLevel
+          }? Come on. You need to step up your game.`
+        if (mastery.championPoints >= "500000")
+          comment = `Your dedication... is admirable.`
+        if (mastery.championPoints >= "1000000")
+          comment = `You're amongst the most loyal acolytes. You deserve a cookie. :cookie:`
+        if (mastery.championPoints >= "100000" && mastery.championLevel < 6)
+          comment = `Over 100k points and yet, still no level 7. _sighs heavily_`
 
-            if (chest == true)
-                chest = ":white_check_mark:";
-            else chest = ":negative_squared_cross_mark:";
+        if (chest == true) chest = ":white_check_mark:"
+        else chest = ":negative_squared_cross_mark:"
 
-            return callback(`\n**Level**: ${Swap.numberToNumberEmoji(mastery.championLevel)}` +
-                `\n**Points**: ${mastery.championPoints}` +
-                `\n**Chest**: ${chest}` +
-                `\n\n ${comment}`);
-        });
-    };
-    api.lastGameSummary = function (matchData, server, callback) {
-        var gameSummary = `${matchData.gameMode}${Swap.gameModeIDToName(matchData.queueId)} [${input.convertMinutesToHoursAndMinutes(matchData.gameDuration)}]`;
-        var blueTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`;
-        var redTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`;
-        api.extractChampionData(server, championDataAPI => {
-            if (championDataAPI.toString().startsWith(`:warning:`))
-                return callback("error", championDataAPI);
-            var champions = championDataAPI;
-            for (var i = 0; i < matchData.participants.length; i++) {
+        return callback(
+          `\n**Level**: ${Swap.numberToNumberEmoji(mastery.championLevel)}` +
+            `\n**Points**: ${mastery.championPoints}` +
+            `\n**Chest**: ${chest}` +
+            `\n\n ${comment}`
+        )
+      }
+    )
+  }
+  api.lastGameSummary = function(matchData, server, callback) {
+    var gameSummary = `${matchData.gameMode}${Swap.gameModeIDToName(
+      matchData.queueId
+    )} [${input.convertMinutesToHoursAndMinutes(matchData.gameDuration)}]`
+    var blueTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`
+    var redTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`
+    api.extractChampionData(server, championDataAPI => {
+      if (championDataAPI.toString().startsWith(`:warning:`))
+        return callback("error", championDataAPI)
+      var champions = championDataAPI
+      for (var i = 0; i < matchData.participants.length; i++) {
+        var player = matchData.participants[i]
+        var kda = `${player.stats.kills}/${player.stats.deaths}/${
+          player.stats.assists
+        }`
+        var level = `${player.stats.champLevel}`
+        var gold = `${player.stats.goldEarned}`
+        var damage = `${player.stats.totalDamageDealtToChampions}`
+        var summonerSpells = `${Swap.spellIDToSpellIcon(
+          player.spell1Id
+        )}${Swap.spellIDToSpellIcon(player.spell2Id)}`
 
-                var player = matchData.participants[i];
-                var kda = `${player.stats.kills}/${player.stats.deaths}/${player.stats.assists}`;
-                var level = `${player.stats.champLevel}`;
-                var gold = `${player.stats.goldEarned}`;
-                var damage = `${player.stats.totalDamageDealtToChampions}`;
-                var summonerSpells = `${Swap.spellIDToSpellIcon(player.spell1Id)}${Swap.spellIDToSpellIcon(player.spell2Id)}`;
+        var playerNick = api.returnsNickIfRankedGame(matchData, i)
 
-                var playerNick = api.returnsNickIfRankedGame(matchData,i);
-
-                if (player.teamId == 100) {
-                    blueTeam += `${summonerSpells} \`\`| ${input.justifyToRight(kda, 8)} | ${input.justifyToRight(gold, 5)} | ${input.justifyToRight(damage, 6)} | ${input.justifyToRight(level, 2)} ` +
-                        `| \`\` **${champions.data[player.championId].name}** ${playerNick} \n`;
-                }
-                else {
-                    redTeam += `${summonerSpells} \`\`| ${input.justifyToRight(kda, 8)} | ${input.justifyToRight(gold, 5)} | ${input.justifyToRight(damage, 6)} | ${input.justifyToRight(level, 2)} ` +
-                        `| \`\` **${champions.data[player.championId].name}** ${playerNick} \n`;
-                }
-            };
-            return callback(`${gameSummary}`,
-                [[api.blueTeamSummary(matchData), blueTeam, false],
-                [api.redTeamSummary(matchData), redTeam, false]]);
-        });
-    };
-    api.blueTeamSummary = function (matchData) {
-        var blueTeamSummary = `<:turretblue:316314784532398080>${matchData.teams[0].towerKills} ` +
-            `<:inhibblue:316314783924092930> ${matchData.teams[0].inhibitorKills} ` +
-            `<:dragonblue:316314783596937218>${matchData.teams[0].dragonKills} ` +
-            `<:baronblue:316314783874023434> ${matchData.teams[0].baronKills} ` +
-            `<:heraldblue:316314784138002442> ${matchData.teams[0].riftHeraldKills} `;
-        if (api.whichTeamWon(matchData) == `BLUE`)
-            blueTeamSummary += `\`\`.......\`\`:trophy:`;
-        return blueTeamSummary;
-    };
-    api.redTeamSummary = function (matchData) {
-        var redTeamSummary = `<:turretred:316314784465420290>${matchData.teams[1].towerKills} ` +
-            `<:inhibred:316314784146653185> ${matchData.teams[1].inhibitorKills} ` +
-            `<:dragonred:316314783915835393>${matchData.teams[1].dragonKills} ` +
-            `<:baronred:316314783634685952> ${matchData.teams[1].baronKills} ` +
-            `<:heraldred:316314784209305600> ${matchData.teams[1].riftHeraldKills} `;
-        if (api.whichTeamWon(matchData) == `RED`)
-            redTeamSummary += `\`\`.......\`\`:trophy:`;
-        return redTeamSummary;
-    };
-    api.returnsNickIfRankedGame = function (matchData,i) {
-        try {
-            return `- ${matchData.participantIdentities[i].player.summonerName}`;
+        if (player.teamId == 100) {
+          blueTeam +=
+            `${summonerSpells} \`\`| ${input.justifyToRight(
+              kda,
+              8
+            )} | ${input.justifyToRight(gold, 5)} | ${input.justifyToRight(
+              damage,
+              6
+            )} | ${input.justifyToRight(level, 2)} ` +
+            `| \`\` **${
+              champions.data[player.championId].name
+            }** ${playerNick} \n`
+        } else {
+          redTeam +=
+            `${summonerSpells} \`\`| ${input.justifyToRight(
+              kda,
+              8
+            )} | ${input.justifyToRight(gold, 5)} | ${input.justifyToRight(
+              damage,
+              6
+            )} | ${input.justifyToRight(level, 2)} ` +
+            `| \`\` **${
+              champions.data[player.championId].name
+            }** ${playerNick} \n`
         }
-        catch (err) {
-            return ``;
-        }
-    };
-    api.whichTeamWon = function (matchData) {
-        if (matchData.teams[0].win == `Win`)
-            return `BLUE`;
-        return `RED`;
-    };
+      }
+      return callback(`${gameSummary}`, [
+        [api.blueTeamSummary(matchData), blueTeam, false],
+        [api.redTeamSummary(matchData), redTeam, false]
+      ])
+    })
+  }
+  api.blueTeamSummary = function(matchData) {
+    var blueTeamSummary =
+      `<:turretblue:316314784532398080>${matchData.teams[0].towerKills} ` +
+      `<:inhibblue:316314783924092930> ${matchData.teams[0].inhibitorKills} ` +
+      `<:dragonblue:316314783596937218>${matchData.teams[0].dragonKills} ` +
+      `<:baronblue:316314783874023434> ${matchData.teams[0].baronKills} ` +
+      `<:heraldblue:316314784138002442> ${matchData.teams[0].riftHeraldKills} `
+    if (api.whichTeamWon(matchData) == `BLUE`)
+      blueTeamSummary += `\`\`.......\`\`:trophy:`
+    return blueTeamSummary
+  }
+  api.redTeamSummary = function(matchData) {
+    var redTeamSummary =
+      `<:turretred:316314784465420290>${matchData.teams[1].towerKills} ` +
+      `<:inhibred:316314784146653185> ${matchData.teams[1].inhibitorKills} ` +
+      `<:dragonred:316314783915835393>${matchData.teams[1].dragonKills} ` +
+      `<:baronred:316314783634685952> ${matchData.teams[1].baronKills} ` +
+      `<:heraldred:316314784209305600> ${matchData.teams[1].riftHeraldKills} `
+    if (api.whichTeamWon(matchData) == `RED`)
+      redTeamSummary += `\`\`.......\`\`:trophy:`
+    return redTeamSummary
+  }
+  api.returnsNickIfRankedGame = function(matchData, i) {
+    try {
+      return `- ${matchData.participantIdentities[i].player.summonerName}`
+    } catch (err) {
+      return ``
+    }
+  }
+  api.whichTeamWon = function(matchData) {
+    if (matchData.teams[0].win == `Win`) return `BLUE`
+    return `RED`
+  }
 
-    api.extractFromUrl = extractFromUrl;
-};
+  api.extractFromUrl = extractFromUrl
+}

--- a/classes/API.js
+++ b/classes/API.js
@@ -1,6 +1,6 @@
 ﻿var request = require('request');
 var Swap = require('./swap.js');
-var Input = require('./input.js');
+var input = require('./input.js');
 
 /**
  * Sends a request to the given URL and calls the callback when it receives a response.
@@ -26,7 +26,6 @@ function extractFromUrl(url, cb) {
 
 exports.API = function () {
     var api = this;
-    var input = new Input.Input();
 
     api.RITO_KEY = process.env.RITO_KEY;
 

--- a/classes/API.js
+++ b/classes/API.js
@@ -57,63 +57,63 @@ exports.API = function () {
     };
 
     api.extractGameTimelineData = function (server, matchID, callback) {
-        api.extractFromURL(api.URLgameTimeline(server, matchID), (err, timelineAPI) => {
+        extractFromUrl(api.URLgameTimeline(server, matchID), (err, timelineAPI) => {
             if (err)
                 return callback(`:warning: Error retrieving game timeline.`);
             return callback(JSON.parse(timelineAPI));
         });
     };
     api.extractPlayerRanksData = function (server, playerID, callback) {
-        api.extractFromURL(api.playersRanksData(server, playerID), (err, ranksAPI) => {
+        extractFromUrl(api.playersRanksData(server, playerID), (err, ranksAPI) => {
             if (err)
                 return callback(`:warning: Error retrieving ranks data.`);
             return callback(JSON.parse(ranksAPI));
         });
     };
     api.extractMatchData = function (server, matchID, callback) {
-        api.extractFromURL(api.URLmatchData(server, matchID), (err, matchDataAPI) => {
+        extractFromUrl(api.URLmatchData(server, matchID), (err, matchDataAPI) => {
             if (err)
                 return callback(":warning: Error retrieving match data.");
             return callback(JSON.parse(matchDataAPI));
         });
     };
     api.extractRecentGamesData = function (server, accountID, callback) {
-        api.extractFromURL(api.URLrecentGamesData(server, accountID), (err, gameDataAPI) => {
+        extractFromUrl(api.URLrecentGamesData(server, accountID), (err, gameDataAPI) => {
             if (err)
                 return callback(":warning: Error retrieving recent games data.");
             return callback(JSON.parse(gamesDataAPI));
         });
     };
     api.extractChampionData = function (server, callback) {
-        api.extractFromURL(api.URLchampionData(server), (err, championDataAPI) => {
+        extractFromUrl(api.URLchampionData(server), (err, championDataAPI) => {
             if (err)
                 return callback(":warning: Error retrieving champion data.");
             return callback(JSON.parse(championDataAPI));
         });
     };
     api.extractPlayersLiveGameData = function (server, playerID, callback) {
-        api.extractFromURL(api.URLliveGameData(server, playerID), (err, liveGameDataAPI) => {
+        extractFromUrl(api.URLliveGameData(server, playerID), (err, liveGameDataAPI) => {
             if (err)
                 return callback(`:warning: This person either is not in game, or you did something wrong.`);
             return callback(JSON.parse(liveGameDataAPI));
         });
     };
     api.extractPlayerID = function (server, playerIGNAndServer, callback) {
-        api.extractFromURL(api.URLsummonerID(server, playerIGNAndServer[0]), (err, playerIDAPI) => {
+        extractFromUrl(api.URLsummonerID(server, playerIGNAndServer[0]), (err, playerIDAPI) => {
             if (err)
                 return callback(`:warning: Player ${decodeURIComponent(playerIGNAndServer[0]).toUpperCase()} doesn't exist.`);
             return callback((JSON.parse(playerIDAPI)).id.toString());
         });
     };
     api.extractPlayerAccountID = function (server, playerIGNAndServer, callback) {
-        api.extractFromURL(api.URLsummonerID(server, playerIGNAndServer[0]), (err, playerIDAPI) => {
+        extractFromUrl(api.URLsummonerID(server, playerIGNAndServer[0]), (err, playerIDAPI) => {
             if (err)
                 return callback(`:warning: Player ${decodeURIComponent(playerIGNAndServer[0]).toUpperCase()} doesn't exist.`);
             return callback((JSON.parse(playerIDAPI)).accountId.toString());
         });
     };
     api.extractPlayerMastery = function (server, playerID, callback) {
-        api.extractFromURL(api.URLmasteryData(server, playerID), (err, championMasteryDataAPI) => {
+        extractFromUrl(api.URLmasteryData(server, playerID), (err, championMasteryDataAPI) => {
             if (err)
                 return callback(`:warning: This person didn't play a single game of me. _Phew_.`);
 
@@ -204,5 +204,5 @@ exports.API = function () {
         return `RED`;
     };
 
-    api.extractFromURL = extractFromUrl;
+    api.extractFromUrl = extractFromUrl;
 };

--- a/classes/API.js
+++ b/classes/API.js
@@ -89,214 +89,226 @@ function URLgameTimeline(matchID) {
   return `/lol/match/v3/timelines/by-match/${matchID}`
 }
 
-exports.API = function() {
-  var api = this
-  api.extractGameTimelineData = function(server, matchID, callback) {
-    makeRiotRequest(server, URLgameTimeline(matchID), (err, timelineAPI) => {
-      if (err) return callback(`:warning: Error retrieving game timeline.`)
-      return callback(JSON.parse(timelineAPI))
-    })
-  }
-  api.extractPlayerRanksData = function(server, playerID, callback) {
-    makeRiotRequest(server, api.playersRanksData(playerID), (err, ranksAPI) => {
-      if (err) return callback(`:warning: Error retrieving ranks data.`)
-      return callback(JSON.parse(ranksAPI))
-    })
-  }
-  api.extractMatchData = function(server, matchID, callback) {
-    makeRiotRequest(server, URLmatchData(matchID), (err, matchDataAPI) => {
-      if (err) return callback(":warning: Error retrieving match data.")
-      return callback(JSON.parse(matchDataAPI))
-    })
-  }
-  api.extractRecentGamesData = function(server, accountID, callback) {
-    makeRiotRequest(
-      server,
-      URLrecentGamesData(accountID),
-      (err, gameDataAPI) => {
-        if (err)
-          return callback(":warning: Error retrieving recent games data.")
-        return callback(JSON.parse(gamesDataAPI))
-      }
-    )
-  }
-  api.extractChampionData = function(server, callback) {
-    makeRiotRequest(server, URLchampionData(), (err, championDataAPI) => {
-      if (err) return callback(":warning: Error retrieving champion data.")
-      return callback(JSON.parse(championDataAPI))
-    })
-  }
-  api.extractPlayersLiveGameData = function(server, playerID, callback) {
-    makeRiotRequest(
-      server,
-      URLliveGameData(playerID),
-      (err, liveGameDataAPI) => {
-        if (err)
-          return callback(
-            `:warning: This person either is not in game, or you did something wrong.`
-          )
-        return callback(JSON.parse(liveGameDataAPI))
-      }
-    )
-  }
-  api.extractPlayerID = function(server, playerIGNAndServer, callback) {
-    makeRiotRequest(
-      server,
-      URLsummonerID(playerIGNAndServer[0]),
-      (err, playerIDAPI) => {
-        if (err)
-          return callback(
-            `:warning: Player ${decodeURIComponent(
-              playerIGNAndServer[0]
-            ).toUpperCase()} doesn't exist.`
-          )
-        return callback(JSON.parse(playerIDAPI).id.toString())
-      }
-    )
-  }
-  api.extractPlayerAccountID = function(server, playerIGNAndServer, callback) {
-    makeRiotRequest(
-      server,
-      URLsummonerID(playerIGNAndServer[0]),
-      (err, playerIDAPI) => {
-        if (err)
-          return callback(
-            `:warning: Player ${decodeURIComponent(
-              playerIGNAndServer[0]
-            ).toUpperCase()} doesn't exist.`
-          )
-        return callback(JSON.parse(playerIDAPI).accountId.toString())
-      }
-    )
-  }
-  api.extractPlayerMastery = function(server, playerID, callback) {
-    makeRiotRequest(
-      server,
-      URLmasteryData(playerID),
-      (err, championMasteryDataAPI) => {
-        if (err)
-          return callback(
-            `:warning: This person didn't play a single game of me. _Phew_.`
-          )
-
-        var mastery = JSON.parse(championMasteryDataAPI)
-        var chest = mastery.chestGranted
-        var comment = ``
-
-        if (!chest)
-          comment = `...how the hell you don't have a chest yet? <:vikwat:269523937669545987>`
-        if (mastery.championLevel <= 4)
-          comment = `...only level ${
-            mastery.championLevel
-          }? Come on. You need to step up your game.`
-        if (mastery.championPoints >= "500000")
-          comment = `Your dedication... is admirable.`
-        if (mastery.championPoints >= "1000000")
-          comment = `You're amongst the most loyal acolytes. You deserve a cookie. :cookie:`
-        if (mastery.championPoints >= "100000" && mastery.championLevel < 6)
-          comment = `Over 100k points and yet, still no level 7. _sighs heavily_`
-
-        if (chest == true) chest = ":white_check_mark:"
-        else chest = ":negative_squared_cross_mark:"
-
-        return callback(
-          `\n**Level**: ${Swap.numberToNumberEmoji(mastery.championLevel)}` +
-            `\n**Points**: ${mastery.championPoints}` +
-            `\n**Chest**: ${chest}` +
-            `\n\n ${comment}`
-        )
-      }
-    )
-  }
-  api.lastGameSummary = function(matchData, server, callback) {
-    var gameSummary = `${matchData.gameMode}${Swap.gameModeIDToName(
-      matchData.queueId
-    )} [${input.convertMinutesToHoursAndMinutes(matchData.gameDuration)}]`
-    var blueTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`
-    var redTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`
-    api.extractChampionData(server, championDataAPI => {
-      if (championDataAPI.toString().startsWith(`:warning:`))
-        return callback("error", championDataAPI)
-      var champions = championDataAPI
-      for (var i = 0; i < matchData.participants.length; i++) {
-        var player = matchData.participants[i]
-        var kda = `${player.stats.kills}/${player.stats.deaths}/${
-          player.stats.assists
-        }`
-        var level = `${player.stats.champLevel}`
-        var gold = `${player.stats.goldEarned}`
-        var damage = `${player.stats.totalDamageDealtToChampions}`
-        var summonerSpells = `${Swap.spellIDToSpellIcon(
-          player.spell1Id
-        )}${Swap.spellIDToSpellIcon(player.spell2Id)}`
-
-        var playerNick = api.returnsNickIfRankedGame(matchData, i)
-
-        if (player.teamId == 100) {
-          blueTeam +=
-            `${summonerSpells} \`\`| ${input.justifyToRight(
-              kda,
-              8
-            )} | ${input.justifyToRight(gold, 5)} | ${input.justifyToRight(
-              damage,
-              6
-            )} | ${input.justifyToRight(level, 2)} ` +
-            `| \`\` **${
-              champions.data[player.championId].name
-            }** ${playerNick} \n`
-        } else {
-          redTeam +=
-            `${summonerSpells} \`\`| ${input.justifyToRight(
-              kda,
-              8
-            )} | ${input.justifyToRight(gold, 5)} | ${input.justifyToRight(
-              damage,
-              6
-            )} | ${input.justifyToRight(level, 2)} ` +
-            `| \`\` **${
-              champions.data[player.championId].name
-            }** ${playerNick} \n`
-        }
-      }
-      return callback(`${gameSummary}`, [
-        [api.blueTeamSummary(matchData), blueTeam, false],
-        [api.redTeamSummary(matchData), redTeam, false]
-      ])
-    })
-  }
-  api.blueTeamSummary = function(matchData) {
-    var blueTeamSummary =
-      `<:turretblue:316314784532398080>${matchData.teams[0].towerKills} ` +
-      `<:inhibblue:316314783924092930> ${matchData.teams[0].inhibitorKills} ` +
-      `<:dragonblue:316314783596937218>${matchData.teams[0].dragonKills} ` +
-      `<:baronblue:316314783874023434> ${matchData.teams[0].baronKills} ` +
-      `<:heraldblue:316314784138002442> ${matchData.teams[0].riftHeraldKills} `
-    if (api.whichTeamWon(matchData) == `BLUE`)
-      blueTeamSummary += `\`\`.......\`\`:trophy:`
-    return blueTeamSummary
-  }
-  api.redTeamSummary = function(matchData) {
-    var redTeamSummary =
-      `<:turretred:316314784465420290>${matchData.teams[1].towerKills} ` +
-      `<:inhibred:316314784146653185> ${matchData.teams[1].inhibitorKills} ` +
-      `<:dragonred:316314783915835393>${matchData.teams[1].dragonKills} ` +
-      `<:baronred:316314783634685952> ${matchData.teams[1].baronKills} ` +
-      `<:heraldred:316314784209305600> ${matchData.teams[1].riftHeraldKills} `
-    if (api.whichTeamWon(matchData) == `RED`)
-      redTeamSummary += `\`\`.......\`\`:trophy:`
-    return redTeamSummary
-  }
-  api.returnsNickIfRankedGame = function(matchData, i) {
-    try {
-      return `- ${matchData.participantIdentities[i].player.summonerName}`
-    } catch (err) {
-      return ``
-    }
-  }
-  api.whichTeamWon = function(matchData) {
-    if (matchData.teams[0].win == `Win`) return `BLUE`
-    return `RED`
-  }
-
-  api.extractFromUrl = extractFromUrl
+function extractGameTimelineData(server, matchID, callback) {
+  makeRiotRequest(server, URLgameTimeline(matchID), (err, timelineAPI) => {
+    if (err) return callback(`:warning: Error retrieving game timeline.`)
+    return callback(JSON.parse(timelineAPI))
+  })
 }
+
+function extractPlayerRanksData(server, playerID, callback) {
+  makeRiotRequest(server, playersRanksData(playerID), (err, ranksAPI) => {
+    if (err) return callback(`:warning: Error retrieving ranks data.`)
+    return callback(JSON.parse(ranksAPI))
+  })
+}
+
+function extractMatchData(server, matchID, callback) {
+  makeRiotRequest(server, URLmatchData(matchID), (err, matchDataAPI) => {
+    if (err) return callback(":warning: Error retrieving match data.")
+    return callback(JSON.parse(matchDataAPI))
+  })
+}
+
+function extractRecentGamesData(server, accountID, callback) {
+  makeRiotRequest(server, URLrecentGamesData(accountID), (err, gameDataAPI) => {
+    if (err) return callback(":warning: Error retrieving recent games data.")
+    return callback(JSON.parse(gamesDataAPI))
+  })
+}
+
+function extractChampionData(server, callback) {
+  makeRiotRequest(server, URLchampionData(), (err, championDataAPI) => {
+    if (err) return callback(":warning: Error retrieving champion data.")
+    return callback(JSON.parse(championDataAPI))
+  })
+}
+
+function extractPlayersLiveGameData(server, playerID, callback) {
+  makeRiotRequest(server, URLliveGameData(playerID), (err, liveGameDataAPI) => {
+    if (err)
+      return callback(
+        `:warning: This person either is not in game, or you did something wrong.`
+      )
+    return callback(JSON.parse(liveGameDataAPI))
+  })
+}
+
+function extractPlayerID(server, playerIGNAndServer, callback) {
+  makeRiotRequest(
+    server,
+    URLsummonerID(playerIGNAndServer[0]),
+    (err, playerIDAPI) => {
+      if (err)
+        return callback(
+          `:warning: Player ${decodeURIComponent(
+            playerIGNAndServer[0]
+          ).toUpperCase()} doesn't exist.`
+        )
+      return callback(JSON.parse(playerIDAPI).id.toString())
+    }
+  )
+}
+
+function extractPlayerAccountID(server, playerIGNAndServer, callback) {
+  makeRiotRequest(
+    server,
+    URLsummonerID(playerIGNAndServer[0]),
+    (err, playerIDAPI) => {
+      if (err)
+        return callback(
+          `:warning: Player ${decodeURIComponent(
+            playerIGNAndServer[0]
+          ).toUpperCase()} doesn't exist.`
+        )
+      return callback(JSON.parse(playerIDAPI).accountId.toString())
+    }
+  )
+}
+
+function extractPlayerMastery(server, playerID, callback) {
+  makeRiotRequest(
+    server,
+    URLmasteryData(playerID),
+    (err, championMasteryDataAPI) => {
+      if (err)
+        return callback(
+          `:warning: This person didn't play a single game of me. _Phew_.`
+        )
+
+      var mastery = JSON.parse(championMasteryDataAPI)
+      var chest = mastery.chestGranted
+      var comment = ``
+
+      if (!chest)
+        comment = `...how the hell you don't have a chest yet? <:vikwat:269523937669545987>`
+      if (mastery.championLevel <= 4)
+        comment = `...only level ${
+          mastery.championLevel
+        }? Come on. You need to step up your game.`
+      if (mastery.championPoints >= "500000")
+        comment = `Your dedication... is admirable.`
+      if (mastery.championPoints >= "1000000")
+        comment = `You're amongst the most loyal acolytes. You deserve a cookie. :cookie:`
+      if (mastery.championPoints >= "100000" && mastery.championLevel < 6)
+        comment = `Over 100k points and yet, still no level 7. _sighs heavily_`
+
+      if (chest == true) chest = ":white_check_mark:"
+      else chest = ":negative_squared_cross_mark:"
+
+      return callback(
+        `\n**Level**: ${Swap.numberToNumberEmoji(mastery.championLevel)}` +
+          `\n**Points**: ${mastery.championPoints}` +
+          `\n**Chest**: ${chest}` +
+          `\n\n ${comment}`
+      )
+    }
+  )
+}
+
+function lastGameSummary(matchData, server, callback) {
+  var gameSummary = `${matchData.gameMode}${Swap.gameModeIDToName(
+    matchData.queueId
+  )} [${input.convertMinutesToHoursAndMinutes(matchData.gameDuration)}]`
+  var blueTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`
+  var redTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`
+  extractChampionData(server, championDataAPI => {
+    if (championDataAPI.toString().startsWith(`:warning:`))
+      return callback("error", championDataAPI)
+    var champions = championDataAPI
+    for (var i = 0; i < matchData.participants.length; i++) {
+      var player = matchData.participants[i]
+      var kda = `${player.stats.kills}/${player.stats.deaths}/${
+        player.stats.assists
+      }`
+      var level = `${player.stats.champLevel}`
+      var gold = `${player.stats.goldEarned}`
+      var damage = `${player.stats.totalDamageDealtToChampions}`
+      var summonerSpells = `${Swap.spellIDToSpellIcon(
+        player.spell1Id
+      )}${Swap.spellIDToSpellIcon(player.spell2Id)}`
+
+      var playerNick = returnsNickIfRankedGame(matchData, i)
+
+      if (player.teamId == 100) {
+        blueTeam +=
+          `${summonerSpells} \`\`| ${input.justifyToRight(
+            kda,
+            8
+          )} | ${input.justifyToRight(gold, 5)} | ${input.justifyToRight(
+            damage,
+            6
+          )} | ${input.justifyToRight(level, 2)} ` +
+          `| \`\` **${
+            champions.data[player.championId].name
+          }** ${playerNick} \n`
+      } else {
+        redTeam +=
+          `${summonerSpells} \`\`| ${input.justifyToRight(
+            kda,
+            8
+          )} | ${input.justifyToRight(gold, 5)} | ${input.justifyToRight(
+            damage,
+            6
+          )} | ${input.justifyToRight(level, 2)} ` +
+          `| \`\` **${
+            champions.data[player.championId].name
+          }** ${playerNick} \n`
+      }
+    }
+    return callback(`${gameSummary}`, [
+      [blueTeamSummary(matchData), blueTeam, false],
+      [redTeamSummary(matchData), redTeam, false]
+    ])
+  })
+}
+
+function blueTeamSummary(matchData) {
+  var blueTeamSummary =
+    `<:turretblue:316314784532398080>${matchData.teams[0].towerKills} ` +
+    `<:inhibblue:316314783924092930> ${matchData.teams[0].inhibitorKills} ` +
+    `<:dragonblue:316314783596937218>${matchData.teams[0].dragonKills} ` +
+    `<:baronblue:316314783874023434> ${matchData.teams[0].baronKills} ` +
+    `<:heraldblue:316314784138002442> ${matchData.teams[0].riftHeraldKills} `
+  if (whichTeamWon(matchData) == `BLUE`)
+    blueTeamSummary += `\`\`.......\`\`:trophy:`
+  return blueTeamSummary
+}
+
+function redTeamSummary(matchData) {
+  var redTeamSummary =
+    `<:turretred:316314784465420290>${matchData.teams[1].towerKills} ` +
+    `<:inhibred:316314784146653185> ${matchData.teams[1].inhibitorKills} ` +
+    `<:dragonred:316314783915835393>${matchData.teams[1].dragonKills} ` +
+    `<:baronred:316314783634685952> ${matchData.teams[1].baronKills} ` +
+    `<:heraldred:316314784209305600> ${matchData.teams[1].riftHeraldKills} `
+  if (whichTeamWon(matchData) == `RED`)
+    redTeamSummary += `\`\`.......\`\`:trophy:`
+  return redTeamSummary
+}
+
+function returnsNickIfRankedGame(matchData, i) {
+  try {
+    return `- ${matchData.participantIdentities[i].player.summonerName}`
+  } catch (err) {
+    return ``
+  }
+}
+
+function whichTeamWon(matchData) {
+  if (matchData.teams[0].win == `Win`) return `BLUE`
+  return `RED`
+}
+
+exports.extractFromUrl = extractFromUrl
+exports.extractPlayerAccountID = extractPlayerAccountID
+exports.extractRecentGamesData = extractRecentGamesData
+exports.extractMatchData = extractMatchData
+exports.extractGameTimelineData = extractGameTimelineData
+exports.extractRecentGamesData = extractRecentGamesData
+exports.lastGameSummary = lastGameSummary
+exports.extractPlayerID = extractPlayerID
+exports.extractPlayersLiveGameData = extractPlayersLiveGameData
+exports.extractChampionData = extractChampionData
+exports.extractPlayerRanksData = extractPlayerRanksData
+exports.extractPlayerMastery = extractPlayerMastery

--- a/classes/API.js
+++ b/classes/API.js
@@ -23,9 +23,9 @@ function extractFromUrl(url, cb) {
     })
 }
 
+
 exports.API = function () {
     var api = this;
-    var swap = new Swap.Swap();
     var input = new Input.Input();
 
     api.RITO_KEY = process.env.RITO_KEY;
@@ -131,14 +131,14 @@ exports.API = function () {
                 chest = ":white_check_mark:";
             else chest = ":negative_squared_cross_mark:";
 
-            return callback(`\n**Level**: ${swap.numberToNumberEmoji(mastery.championLevel)}` +
+            return callback(`\n**Level**: ${Swap.numberToNumberEmoji(mastery.championLevel)}` +
                 `\n**Points**: ${mastery.championPoints}` +
                 `\n**Chest**: ${chest}` +
                 `\n\n ${comment}`);
         });
     };
     api.lastGameSummary = function (matchData, server, callback) {
-        var gameSummary = `${matchData.gameMode}${swap.gameModeIDToName(matchData.queueId)} [${input.convertMinutesToHoursAndMinutes(matchData.gameDuration)}]`;
+        var gameSummary = `${matchData.gameMode}${Swap.gameModeIDToName(matchData.queueId)} [${input.convertMinutesToHoursAndMinutes(matchData.gameDuration)}]`;
         var blueTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`;
         var redTeam = `\`\`.       |    KDA   |  gold |    dmg | lv |\`\`\n\`\`------------------------------------------\`\`\n`;
         api.extractChampionData(server, championDataAPI => {
@@ -152,7 +152,7 @@ exports.API = function () {
                 var level = `${player.stats.champLevel}`;
                 var gold = `${player.stats.goldEarned}`;
                 var damage = `${player.stats.totalDamageDealtToChampions}`;
-                var summonerSpells = `${swap.spellIDToSpellIcon(player.spell1Id)}${swap.spellIDToSpellIcon(player.spell2Id)}`;
+                var summonerSpells = `${Swap.spellIDToSpellIcon(player.spell1Id)}${Swap.spellIDToSpellIcon(player.spell2Id)}`;
 
                 var playerNick = api.returnsNickIfRankedGame(matchData,i);
 

--- a/classes/answer.js
+++ b/classes/answer.js
@@ -1,6 +1,6 @@
 ﻿var Commands = require('./commands.js');
 var RNG = require('./rng.js');
-var Input = require('./input.js');
+var input = require('./input.js');
 var DearViktorAnswers = require('./dearviktoranswers.js');
 var Matchup = require('./matchup.js');
 var Roles = require('./roles.js');
@@ -12,7 +12,6 @@ var API = require('./API.js');
 exports.Answer = function (data) {
     var answer = this;
     var rng = new RNG.RNG();
-    var input = new Input.Input();
     var post = new Post.Post(data);
 
     answer.userMessage = data.message;
@@ -44,8 +43,6 @@ exports.Answer = function (data) {
     answer.showHelpContents = function () {
         var Commands = require('./commands.js');
         var commands = new Commands.Commands('');
-        var Input = require('./input.js');
-        var input = new Input.Input();
         var helpContents = '```List of commands:\n\n';
 
         for (var property in commands.listOfResponses) {

--- a/classes/answer.js
+++ b/classes/answer.js
@@ -20,7 +20,7 @@ exports.Answer = function (data) {
 
     answer.toBuild = function (title) {
         var build = [];
-       
+
         build[0] = [`First Back Purchases`,
             `**< 1250 gold:** <:darkseal:315619117103316992> + <:refillable:315619119007531028> / <:doran:315619117287735306> + <:refillable:315619119007531028>\n` +
             `**>= 1250 gold:** <:hc1:315619117346586625> + <:refillable:315619119007531028>\n`,
@@ -32,7 +32,7 @@ exports.Answer = function (data) {
             `\n\n**Pros:** \n• very high DPS \n• godlike late game with a potential to oneshot a squishy every ~3 seconds \n• makes Viktor a great tank killer` +
             `\n**Cons:** \n• weak in early- and midgame \n• worthless in early skirmishes \n• need to remain in autoattack range for full effectiveness`,
             false];
-        
+
         post.embedToDM(title, build, data.message.author);
     }
     answer.toBuildTrigger = function () {
@@ -174,7 +174,7 @@ exports.Answer = function (data) {
             answer[cmd.triggers](cmd.arguments);
         }
     };
-    
+
 
     answer.toBan = function (typeOfRequest) {
         var Ban = require('./mod/ban.js');
@@ -226,7 +226,7 @@ exports.Answer = function (data) {
     answer.toAntiSpam = function () {
         var Mods = require('./mod/mods.js');
         var mods = new Mods.Mods(data);
-        
+
         if (input.removeKeyword(data.message.content) == ``)
             return mods.turnAntiSpamOnOrOff();
         return mods.setUpAntiSpam();
@@ -257,7 +257,7 @@ exports.Answer = function (data) {
     answer.toSkinTimer = function () {
         var dateCreator = Date.UTC(2013, 9, 1);
         var datePromised = Date.UTC(2018, 4, 3);
-        var dateNow = new Date(); 
+        var dateNow = new Date();
         dateNow = Date.now();
 
         var creatorMath = `Creator skin got released at 1st of October, 2013. That gives us ` +
@@ -285,8 +285,8 @@ exports.Answer = function (data) {
     answer.toPBE = function () {
         var api = new API.API();
 
-        api.extractFromURL(`http://www.surrenderat20.net/search/label/PBE/`, surrAt20API => {
-            if (!api.everythingOkay(surrAt20API))
+        api.extractFromURL(`http://www.surrenderat20.net/search/label/PBE/`, (err, surrAt20API) => {
+            if (err)
                 return post.message(`Unable to fetch the newest PBE patch notes.`);
             var findThis = `<h1 class='news-title' itemprop='name'>`;
             surrAt20API = surrAt20API.toString();
@@ -294,8 +294,8 @@ exports.Answer = function (data) {
                 surrAt20API = surrAt20API.substring(surrAt20API.indexOf(findThis) + findThis.length);
                 surrAt20API = surrAt20API.substring(surrAt20API.indexOf(`<a href='`) + 9, surrAt20API.indexOf(`'>`));
 
-                api.extractFromURL(surrAt20API, currentPatchHTML => {
-                    if (!api.everythingOkay(currentPatchHTML))
+                api.extractFromURL(surrAt20API, (err, currentPatchHTML) => {
+                    if (err)
                         return post.message(`Unable to fetch the newest PBE patch notes.`);
                     var newestPBEPatchVersion = currentPatchHTML.toString();
                     try {
@@ -407,7 +407,7 @@ exports.Answer = function (data) {
 
                         return post.embed(`${matchData.participantIdentities[playerIndex].player.summonerName.toUpperCase()} (as champ ${matchData.participants[playerIndex].championId}) ` +
                             `vs ${matchData.participantIdentities[enemyIndex].player.summonerName.toUpperCase()} (as champ ${matchData.participants[enemyIndex].championId}) - ${matchData.participants[playerIndex].timeline.role.toLowerCase() } ${matchData.participants[playerIndex].timeline.lane.toLowerCase() }\n`,
-                                    [[`Minute 5`, gameData[0], false], 
+                                    [[`Minute 5`, gameData[0], false],
                                     [`Minute 10`, gameData[1], false],
                                     [`Minute 15`, gameData[2], false],
                                     [`Outcome`, gameData[3], false]]);
@@ -448,7 +448,7 @@ exports.Answer = function (data) {
                 });
             });
         });
-    }; 
+    };
     answer.toLiveGameRequest = function (title) { //full rework!!!!!
         post.message(`:hourglass_flowing_sand: Getting the Live Game data. This might take a while...`);
         var _input = data.message.content;
@@ -552,7 +552,7 @@ exports.Answer = function (data) {
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]);
         var server = swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
-        
+
         api.extractPlayerID(server, playerIGNAndServer, playerID => {
             if (playerID.startsWith(`:warning:`))
                 return post.message(playerID);
@@ -590,7 +590,7 @@ exports.Answer = function (data) {
                     .then(euwJson => {
                         var euwCom = 'No comments on those boards!';
                         var naCom = 'No comments on those boards!';
-                        
+
                         for (let i in naJson) {
                             if (naJson[i].comment && naJson[i].comment.message.toLowerCase().indexOf('viktor') != -1) {
                                 if (naCom == 'No comments on those boards!')
@@ -621,8 +621,8 @@ exports.Answer = function (data) {
     };
     answer.toCatPicture = function () {
         var api = new API.API();
-        api.extractFromURL('http://random.cat/meow', extractedStuff => {
-            if (!api.everythingOkay(extractedStuff))
+        api.extractFromURL('http://random.cat/meow', (err, extractedStuff) => {
+            if (err)
                 return post.message('Unable to get a cat.');
             var cat = JSON.parse(extractedStuff).file;
             post.message(`${cat} 🐱 :3`);
@@ -630,8 +630,8 @@ exports.Answer = function (data) {
     };
     answer.toDogPicture = function () {
         var api = new API.API();
-        api.extractFromURL('http://random.dog/woof', extractedStuff => {
-            if (!api.everythingOkay(extractedStuff))
+        api.extractFromURL('http://random.dog/woof', (err, extractedStuff) => {
+            if (err)
                 return post.message('Unable to get a dog.');
             post.message(`http://random.dog/${extractedStuff} 🐶 :3`);
         });

--- a/classes/answer.js
+++ b/classes/answer.js
@@ -6,7 +6,7 @@ var Matchup = require('./matchup.js');
 var Roles = require('./roles.js');
 var Race = require('./race.js');
 var Post = require('./post.js');
-var Swap = require('./swap.js');
+var Swap = require('./Swap.js');
 var API = require('./API.js');
 
 exports.Answer = function (data) {
@@ -14,7 +14,6 @@ exports.Answer = function (data) {
     var rng = new RNG.RNG();
     var input = new Input.Input();
     var post = new Post.Post(data);
-    var swap = new Swap.Swap();
 
     answer.userMessage = data.message;
 
@@ -323,7 +322,7 @@ exports.Answer = function (data) {
         var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]).toUpperCase();
-        var server = swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
+        var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
         api.extractPlayerAccountID(server, playerIGNAndServer, accountID => {
             if (accountID.toString().startsWith(`:warning:`))
                 return post.message(accountID);
@@ -426,7 +425,7 @@ exports.Answer = function (data) {
         var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]).toUpperCase();
-        var server = swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
+        var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
 
         api.extractPlayerAccountID(server, playerIGNAndServer, accountID => {
             if (accountID.toString().startsWith(`:warning:`))
@@ -458,7 +457,7 @@ exports.Answer = function (data) {
         var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]).toUpperCase();
-        var server = swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
+        var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
 
         api.extractPlayerID(server, playerIGNAndServer, playerID => {
             if (playerID.toString().startsWith(`:warning:`))
@@ -473,7 +472,7 @@ exports.Answer = function (data) {
                     var ids = "";
                     for (var i = 0; i < game.participants.length; i++)
                         ids += "," + game.participants[i].summonerId;
-                    //api.extractPlayerRanksData(swap.endPointToServer(server), ids.slice(1), ranksData => {
+                    //api.extractPlayerRanksData(Swap.endPointToServer(server), ids.slice(1), ranksData => {
                     //    if (ranksData.toString().startsWith(`:warning:`))
                     //        return post.message(ranksData);
                         var champions = championDataAPI;
@@ -485,7 +484,7 @@ exports.Answer = function (data) {
 
                         for (var i = 0; i <= game.participants.length; i++) {
                             if (i == game.participants.length) {
-                                post.embed(`${title} Live game of ${playerNickDecoded.toUpperCase()} | ${game.gameMode} ${swap.gameModeIDToName(game.gameQueueConfigId)}`,
+                                post.embed(`${title} Live game of ${playerNickDecoded.toUpperCase()} | ${game.gameMode} ${Swap.gameModeIDToName(game.gameQueueConfigId)}`,
                                     [[`:large_blue_circle: Blue Team`, blueTeam, true],
                                     [`:red_circle: Red Team`, redTeam, true],[`___`,`:warning: Ranks and win ratio are temporarily unavailable.`,false]]);
                                 break;
@@ -496,9 +495,9 @@ exports.Answer = function (data) {
                             var wins = 0;
                             var losses = 0;
                             var winRatio = `---`;
-                            var summonerSpells = swap.spellIDToSpellIcon(game.participants[i].spell1Id)+swap.spellIDToSpellIcon(game.participants[i].spell2Id);
+                            var summonerSpells = Swap.spellIDToSpellIcon(game.participants[i].spell1Id)+Swap.spellIDToSpellIcon(game.participants[i].spell2Id);
                             /*if (ranks[game.participants[i].summonerId] != undefined) {
-                                rank = ranks[game.participants[i].summonerId][0].tier.substring(0, 1) + swap.romanToArabic(ranks[game.participants[i].summonerId][0].entries[0].division);
+                                rank = ranks[game.participants[i].summonerId][0].tier.substring(0, 1) + Swap.romanToArabic(ranks[game.participants[i].summonerId][0].entries[0].division);
 
                                 wins = ranks[game.participants[i].summonerId][0].entries[0].wins;
                                 losses = ranks[game.participants[i].summonerId][0].entries[0].losses;
@@ -536,7 +535,7 @@ exports.Answer = function (data) {
         var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]).toUpperCase();
-        var server = swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
+        var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
 
         api.extractPlayerID(server, playerIGNAndServer, playerID => {
             if (playerID.toString().startsWith(`:warning:`))
@@ -551,7 +550,7 @@ exports.Answer = function (data) {
         var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]);
-        var server = swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
+        var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
 
         api.extractPlayerID(server, playerIGNAndServer, playerID => {
             if (playerID.startsWith(`:warning:`))

--- a/classes/answer.js
+++ b/classes/answer.js
@@ -7,7 +7,7 @@ var Roles = require('./roles.js');
 var Race = require('./race.js');
 var Post = require('./post.js');
 var Swap = require('./Swap.js');
-var API = require('./API.js');
+var api = require('./API.js');
 
 exports.Answer = function (data) {
     var answer = this;
@@ -279,8 +279,6 @@ exports.Answer = function (data) {
         return race.leaderboards(rankDesiredCurrentAndLower[0], rankDesiredCurrentAndLower[1], rankDesiredCurrentAndLower[2]);
     };
     answer.toPBE = function () {
-        var api = new API.API();
-
         api.extractFromURL(`http://www.surrenderat20.net/search/label/PBE/`, (err, surrAt20API) => {
             if (err)
                 return post.message(`Unable to fetch the newest PBE patch notes.`);
@@ -316,7 +314,6 @@ exports.Answer = function (data) {
         if (!input.hasSeparator(_input))
             return post.message(`This command requires the symbol \"**|**\" to separate region from nickname. \n_Example:_ \`\`!lastlane ${data.message.author.username}|euw\`\``);
 
-        var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]).toUpperCase();
         var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
@@ -419,7 +416,6 @@ exports.Answer = function (data) {
         if (!input.hasSeparator(_input))
             return post.message(`This command requires the symbol \"**|**\" to separate region from nickname. \n_Example:_ \`\`!lastgame ${data.message.author.username}|euw\`\``);
 
-        var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]).toUpperCase();
         var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
@@ -451,7 +447,6 @@ exports.Answer = function (data) {
         if (!input.hasSeparator(_input))
             return post.message(`This command requires the symbol \"**|**\" to separate region from nickname. \n_Example:_ \`\`!giveid ${data.message.author.username}|euw\`\``);
 
-        var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]).toUpperCase();
         var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
@@ -529,7 +524,6 @@ exports.Answer = function (data) {
         if (!input.hasSeparator(_input))
             return post.message(`This command requires the symbol \"**|**\" to separate region from nickname. \n_Example:_ \`\`!giveid ${data.message.author.username}|euw\`\``);
 
-        var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]).toUpperCase();
         var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
@@ -544,7 +538,6 @@ exports.Answer = function (data) {
         var _input = data.message.content;
         if (!input.hasSeparator(_input))
             return post.message(`This command requires the symbol \"**|**\" to separate region from nickname. \n_Example:_ \`\`!mastery ${data.message.author.username}|euw\`\``);
-        var api = new API.API();
         var playerIGNAndServer = input.returnModifiedIGNAndServer(_input);
         var playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]);
         var server = Swap.serverToEndPoint(playerIGNAndServer[1]); //TODO: this is what every Rito API command looks like - unifize it somehow
@@ -562,7 +555,6 @@ exports.Answer = function (data) {
         post.newStatus(newStatus);
     };
     answer.toRedTracker = function () {
-        var api = new API.API();
         var naPath = `http://boards.na.leagueoflegends.com/en/redtracker.json`;
         var euwPath = `http://boards.euw.leagueoflegends.com/en/redtracker.json`;
         var message = [];
@@ -616,7 +608,6 @@ exports.Answer = function (data) {
             .catch(e => { post.message(`Unable to fetch EUW Riot comments. ${e}`); })
     };
     answer.toCatPicture = function () {
-        var api = new API.API();
         api.extractFromURL('http://random.cat/meow', (err, extractedStuff) => {
             if (err)
                 return post.message('Unable to get a cat.');
@@ -625,7 +616,6 @@ exports.Answer = function (data) {
         });
     };
     answer.toDogPicture = function () {
-        var api = new API.API();
         api.extractFromURL('http://random.dog/woof', (err, extractedStuff) => {
             if (err)
                 return post.message('Unable to get a dog.');

--- a/classes/data/follow.js
+++ b/classes/data/follow.js
@@ -1,4 +1,5 @@
 ﻿var Post = require('../post.js');
+var input = require('../input')
 
 exports.Follow = function (data) {
     var follow = this;
@@ -7,8 +8,6 @@ exports.Follow = function (data) {
     var followersPath = '../data/follow.json';
 
     follow.listOfStreamers = function () {
-        var Input = require('../input.js');
-        var input = new Input.Input();
         var streamersList = ``;
         var viktorStreamers = data.message.guild.roles.find(`name`, roleName).members.forEach(member => {
             streamersList += `\`\`- ${member.user.id}\`\` - **${member.user.username}**\n`;
@@ -21,8 +20,6 @@ exports.Follow = function (data) {
 
     follow.start = function () {
         var fs = require('fs');
-        var Input = require('../input.js');
-        var input = new Input.Input();
 
         var streamerID = input.removeKeyword(data.message.content);
         var streamerExists = data.message.guild.members.find('id', streamerID);
@@ -31,7 +28,7 @@ exports.Follow = function (data) {
             return post.embed(`:warning: Incorrect input`, [[`___`, `**<** and **>** is supposed to indicate that this is a part where you put ` +
                 `the ID. You don't _literally_ put **<** and **>** there. <:vikfacepalm:305783369302802434>`]]);
         if (isNaN(streamerID))
-            return post.embed(`:warning: Incorrect input`, [[`___`, `I suggest writing ID of a person you want to follow.\nYou can find IDs of people to follow using the !streamers command.`, false]]);       
+            return post.embed(`:warning: Incorrect input`, [[`___`, `I suggest writing ID of a person you want to follow.\nYou can find IDs of people to follow using the !streamers command.`, false]]);
         if (!streamerExists)
             return post.embed(`:warning: Incorrect input`, [[`___`, `Person with such ID doesn't exist.`, false]]);
         if (!follow.isViktorStreamer(streamerID))
@@ -54,7 +51,7 @@ exports.Follow = function (data) {
             }
             else {
                 var id = follow.streamerIsOnTheList(followerInfoJson.Streamers, streamerID);
-                
+
                 if (follow.userAlreadyFollows(followerInfoJson.Streamers[id]))
                     return post.embed(`:warning: Can't do it`, [[`___`,`You already follow ${userNick}.`,false]]);
                 followerInfoJson.Streamers[id].followers.push(data.message.author.id);
@@ -66,13 +63,11 @@ exports.Follow = function (data) {
                 };
             });
             return post.embed(`<:viktorgod:269479031009837056> Follower alert`, [[`___`, `**${data.message.author.username}** now follows **${userNick}**.\n\n` +
-                `To see the list of people you follow: \`\`!whoifollow\`\``, false]]); 
+                `To see the list of people you follow: \`\`!whoifollow\`\``, false]]);
         });
     };
     follow.stop = function () {
         var fs = require('fs');
-        var Input = require('../input.js');
-        var input = new Input.Input();
 
         var streamerID = input.removeKeyword(data.message.content);
         var streamerExists = data.message.guild.members.find('id', streamerID);
@@ -112,7 +107,7 @@ exports.Follow = function (data) {
                     return console.log(`Writing follow file: ${err}`);
                 };
             });
-            return post.embed(`<:JustDieAlready:288399448176853012> Unfollower alert`, [[`___`, `**${data.message.author.username}** no longer follows **${userNick}**.`, false]]); 
+            return post.embed(`<:JustDieAlready:288399448176853012> Unfollower alert`, [[`___`, `**${data.message.author.username}** no longer follows **${userNick}**.`, false]]);
         });
     };
     follow.listOfMyFollowers = function () {

--- a/classes/input.js
+++ b/classes/input.js
@@ -1,99 +1,103 @@
-﻿exports.Input = function () {
-    var input = this;
+﻿exports.isLink = function(supposedLink) {
+  if (supposedLink.startsWith(`http`)) return true
+  return false
+}
 
-    input.isLink = function (supposedLink) {
-        if (supposedLink.startsWith(`http`))
-            return true;
-        return false;
-    };
-    input.hasSeparator = function (_input) {
-        if (_input.indexOf('|')!=-1)
-            return true;
-        return false;
-    };
-    input.allKeywordsWereFoundInString = function (keywords, _input) {
-        _input = _input.toLowerCase();
-        for (var i = 0; i < keywords.length; i++) {
-            if (_input.indexOf(keywords[i]) == -1)
-                return false;
-        }
-        return true;
-    };
+exports.hasSeparator = function(_input) {
+  if (_input.indexOf("|") != -1) return true
+  return false
+}
 
+exports.allKeywordsWereFoundInString = function(keywords, _input) {
+  _input = _input.toLowerCase()
+  for (var i = 0; i < keywords.length; i++) {
+    if (_input.indexOf(keywords[i]) == -1) return false
+  }
+  return true
+}
 
-    input.removeOneSymbolPrefix = function (_input) {
-        var output = _input.slice(1).trim();
-        return output;
-    };
-    input.removeKeyword = function (_input) {
-        var output = ``;
-        if (_input.indexOf(` `) != -1)
-            output = _input.slice(_input.indexOf(` `)).trim();
-        return output;
-    };
-    input.extractKeyword = function (_input) {
-        var output = _input.slice(1).trim();
-        if (output.indexOf(' ') !== -1)
-            output = output.slice(0, output.indexOf(' ')).trim();
-        output = output.toLowerCase();
-        return output;
-    };
-    input.subStringBySymbol = function (_input, symbol) {
-        var first = _input.substring(0, _input.indexOf(symbol)).trim();
-        var second = _input.substring(_input.indexOf(symbol)).trim();
-        return [first, second];
-    };
-    input.removeSpaces = function (_input) {
-        var output = _input.toLowerCase();
-        output = output.replace(/ /g, ``);
-        return output;
-    };
+exports.removeOneSymbolPrefix = function(_input) {
+  var output = _input.slice(1).trim()
+  return output
+}
 
+exports.removeKeyword = function(_input) {
+  var output = ``
+  if (_input.indexOf(` `) != -1)
+    output = _input.slice(_input.indexOf(` `)).trim()
+  return output
+}
 
-    input.returnModifiedIGNAndServer = function (_input) {
-        return input.getIGNAndServer(input.getRidOfSpecialSymbols(input.removeSpaces(input.removeKeyword(_input))));
-    };
+exports.extractKeyword = function(_input) {
+  var output = _input.slice(1).trim()
+  if (output.indexOf(" ") !== -1)
+    output = output.slice(0, output.indexOf(" ")).trim()
+  output = output.toLowerCase()
+  return output
+}
 
+exports.subStringBySymbol = function(_input, symbol) {
+  var first = _input.substring(0, _input.indexOf(symbol)).trim()
+  var second = _input.substring(_input.indexOf(symbol)).trim()
+  return [first, second]
+}
 
-    input.getIDOfMentionedPerson = function (_input) {
-        var output = input.removeKeyword(_input);
-        output = output.substring(2, output.length - 1);
-        return output;
-    };
-    input.getIGNAndServer = function (_input) {
-        var output = _input.split(`%7C`);
-        return output;
-    };
-    input.getRidOfSpecialSymbols = function (_input) {
-        return encodeURIComponent(_input);
-    };
-    input.readdSpecialSymbols = function (_input) {
-        return decodeURIComponent(_input);
-    };
+exports.removeSpaces = function(_input) {
+  var output = _input.toLowerCase()
+  output = output.replace(/ /g, ``)
+  return output
+}
 
+exports.returnModifiedIGNAndServer = function(_input) {
+  // HACK: Referring to 'exports' in this way is generally considered a bad idea
+  return exports.getIGNAndServer(
+    exports.getRidOfSpecialSymbols(
+      exports.removeSpaces(exports.removeKeyword(_input))
+    )
+  )
+}
 
-    input.justifyToRight = function (_input, desiredLength) {
-        var output = _input;
-        while (output.length < desiredLength)
-            output = ` ${output}`;
-        return output;
-    };
-    input.justifyToLeft = function (_input, desiredLength) {
-        var output = _input;
-        while (output.length < desiredLength)
-            output += ` `;
-        return output;
-    };
-    input.round= function (number, digits) {
-        var multiple = Math.pow(10, digits);
-        var output = Math.round(number * multiple) / multiple;
-        return output;
-    };
-    input.convertMinutesToHoursAndMinutes = function (minutes) {
-        var h = Math.floor(minutes / 60);
-        var m = minutes % 60;
-        h = h < 10 ? '0' + h : h;
-        m = m < 10 ? '0' + m : m;
-        return h + ':' + m;
-    }
-};  
+exports.getIDOfMentionedPerson = function(_input) {
+  var output = exports.removeKeyword(_input)
+  output = output.substring(2, output.length - 1)
+  return output
+}
+
+exports.getIGNAndServer = function(_input) {
+  var output = _input.split(`%7C`)
+  return output
+}
+
+exports.getRidOfSpecialSymbols = function(_input) {
+  return encodeURIComponent(_input)
+}
+
+exports.readdSpecialSymbols = function(_input) {
+  return decodeURIComponent(_input)
+}
+
+exports.justifyToRight = function(_input, desiredLength) {
+  var output = _input
+  while (output.length < desiredLength) output = ` ${output}`
+  return output
+}
+
+exports.justifyToLeft = function(_input, desiredLength) {
+  var output = _input
+  while (output.length < desiredLength) output += ` `
+  return output
+}
+
+exports.round = function(number, digits) {
+  var multiple = Math.pow(10, digits)
+  var output = Math.round(number * multiple) / multiple
+  return output
+}
+
+exports.convertMinutesToHoursAndMinutes = function(minutes) {
+  var h = Math.floor(minutes / 60)
+  var m = minutes % 60
+  h = h < 10 ? "0" + h : h
+  m = m < 10 ? "0" + m : m
+  return h + ":" + m
+}

--- a/classes/mod/ban.js
+++ b/classes/mod/ban.js
@@ -1,10 +1,10 @@
-﻿exports.Ban = function (data) {
+﻿var input = require('../input');
+
+exports.Ban = function (data) {
     var ban = this;
     var Post = require('../post.js');
-    var Input = require('../input.js');
     var fs = require('fs');
     var post = new Post.Post(data);
-    var input = new Input.Input();
     var banPath = ('../data/mod/blackList.json');
 
     ban.newUserIsBlacklisted = function (GuildMember, callback) {
@@ -28,7 +28,7 @@
     ban.handleUserFromBlacklist = function (GuildMember, banIndex) {
         var d = new Date();
         var serverID = GuildMember.guild.id;
-        
+
         fs.readFile(banPath, 'utf8', (err, fileContents) => {
             if (err)
                 return console.log(`${d} - error while banning blacklisted ${GuildMember.user} who joins!`);
@@ -52,7 +52,7 @@
     };
 
 
-    ban.ban = function () { 
+    ban.ban = function () {
         var d = new Date();
         var banOptions = input.removeKeyword(data.message.content).split('|');
         var idToBan = banOptions[0];
@@ -192,7 +192,7 @@
             if (err)
                 return post.embed(`:warning: Error while unbanning user`, [[`___`, `${err}`, false]]);
             var d = new Date();
-            var serverID = data.message.guild.id; 
+            var serverID = data.message.guild.id;
             var listOfBans = '';
             fileContents = JSON.parse(fileContents);
 

--- a/classes/mod/messageCount.js
+++ b/classes/mod/messageCount.js
@@ -1,12 +1,11 @@
-﻿const Discord = require('discord.js');
+﻿var input = require('../input')
+const Discord = require('discord.js');
 
 exports.MessageCount = function (data) {
     var messageCount = this;
     var fs = require(`fs`);
     var Post = require(`../post.js`);
     var post = new Post.Post(data);
-    var Input = require(`../input.js`);
-    var input = new Input.Input();
     var messageCountPath = `../data/mod/messageCount.json`;
 
     messageCount.getMsgData = function (callback) {
@@ -69,7 +68,7 @@ exports.MessageCount = function (data) {
             };
         });
     };*/
-    
+
     messageCount.checkRegularRequirements = function (userData, msg) {
         //var arrayOfRanks = [`Fresh Acolyte`, `Junior Assistant`, `Hextech Progenitor`, `Arcane Android`];
         var memberRole = 'Junior Assistant';

--- a/classes/mod/mods.js
+++ b/classes/mod/mods.js
@@ -1,4 +1,6 @@
-﻿exports.Mods = function(data) {
+﻿var input = require('../input')
+
+exports.Mods = function(data) {
 	var mods = this;
 	var Post = require(`../post.js`);
 	var post = new Post.Post(data);
@@ -8,8 +10,6 @@
     mods.showModCommands = function () {
         var Commands = require('../commands.js');
         var commands = new Commands.Commands('');
-        var Input = require('../input.js');
-        var input = new Input.Input();
         var helpContents = '```Moderator commands:\n\n';
 
         for (var property in commands.listOfResponses) {
@@ -24,8 +24,6 @@
     // commands to moderate mods
 	mods.promote = function () {
 		var fs = require('fs');
-		var Input = require('../input.js');
-        var input = new Input.Input();
 
 		var modID = input.getIDOfMentionedPerson(data.message.content);
 		var modExists = data.message.mentions.users.find('id', modID);
@@ -58,8 +56,6 @@
 	};
 	mods.demote = function () {
 		var fs = require('fs');
-		var Input = require('../input.js');
-		var input = new Input.Input();
 
 		var modID = input.getIDOfMentionedPerson(data.message.content);
 		var modExists = data.message.mentions.users.find('id', modID);
@@ -101,7 +97,7 @@
                 post.embed(`:no_entry:`, [[`___`, `Something went wrong <:SMB4:310138833377165312>`, false]]);
                 return console.log(`Reading mod file: ${err}`);
             };
-            
+
             serverDataJson = JSON.parse(serverDataJson);
             if (!mods.serverIsListed(serverDataJson))
                 return;
@@ -161,8 +157,6 @@
         });
     };
     mods.restrictCommand = function () {
-        var Input = require('../input.js');
-        var input = new Input.Input();
         var commandAndRoom = input.removeKeyword(data.message.content);
 
         if (!commandAndRoom)
@@ -205,18 +199,16 @@
         });
     };
     mods.setUpAntiSpam = function () {
-        var Input = require('../input.js');
-        var input = new Input.Input();
         var fs = require('fs');
         var spamSettings = input.removeKeyword(data.message.content);
 
         if (!data.antispam)
-            return post.embed(`:warning: Your settings weren't applied...`, [[`___`, `...because antispam is OFF. \nTo turn on antispam, write \`\`!antispam\`\``, false]]); 
+            return post.embed(`:warning: Your settings weren't applied...`, [[`___`, `...because antispam is OFF. \nTo turn on antispam, write \`\`!antispam\`\``, false]]);
         if (spamSettings.indexOf('|') == -1)
             return post.embed(`:warning: Incorrect input`, [[`__`, `This command requires the symbol \"**|**\" to separate \`\`number of messages\`\` from \`\`time limit in seconds\`\`.`, false]]);
         spamSettings = spamSettings.split('|');
         if (spamSettings[0] < 2)
-            return post.embed(`:warning: Incorrect number of messages`, [[`___`, `You can't set up antispam to react for the number of messages lower than 2 because it makes no sense.`, false]]); 
+            return post.embed(`:warning: Incorrect number of messages`, [[`___`, `You can't set up antispam to react for the number of messages lower than 2 because it makes no sense.`, false]]);
 
         fs.readFile(serverDataPath, `utf8`, (err, serverData) => {
             if (err)

--- a/classes/race.js
+++ b/classes/race.js
@@ -1,5 +1,6 @@
 ﻿var Swap = require('./swap')
 var input = require('./input');
+var api = require('./API');
 
 exports.Race = function (data, post) {
     var race = this;
@@ -8,9 +9,6 @@ exports.Race = function (data, post) {
         var fs = require(`fs`);
         var Roles = require('./roles.js');
         var roles = new Roles.Roles(data.message.member);
-        var API = require('./API.js');
-        var api = new API.API();
-
         var playerIGNAndServer;
         var server;
         var playerNickDecoded;
@@ -141,9 +139,6 @@ exports.Race = function (data, post) {
             return callback (raceJson);
     };
     race.assignRankPoints = function (raceJson, rankDesired, rankCurrent, rankLower, callback) {
-        var API = require('./API.js');
-        var api = new API.API();
-
         var l = raceJson.Participants.length;
 
         function raceLoop(i) {

--- a/classes/race.js
+++ b/classes/race.js
@@ -1,4 +1,6 @@
-﻿exports.Race = function (data, post) {
+﻿var Swap = require('./swap')
+
+exports.Race = function (data, post) {
     var race = this;
 
     race.join = function (rankDesiredCurrentAndLower) {
@@ -9,8 +11,6 @@
         var input = new Input.Input();
         var API = require('./API.js');
         var api = new API.API();
-        var Swap = require('./swap.js');
-        var swap = new Swap.Swap();
 
         var playerIGNAndServer;
         var server;
@@ -19,7 +19,7 @@
         var rankCurrent = rankDesiredCurrentAndLower[1];
         var msg = input.removeKeyword(data.message.content).substring(4).trim();
         var racePath = `../data/race/${rankDesired.toLowerCase()}race.json`;
-        
+
         if (!roles.userHasRole('Junior Assistant') && !roles.userHasRole('Hextech Progenitor'))
             return post.message(`:warning: Only members of community can join races! Participate a bit more before joining. Junior Assistant has a very low requirement to get!`);
         if (msg.indexOf(`<`) !== -1)
@@ -35,7 +35,7 @@
         playerIGNAndServer[1] = playerIGNAndServer[1].trim();
         playerIGNAndServer[0] = input.getRidOfSpecialSymbols(playerIGNAndServer[0]);
         playerNickDecoded = input.readdSpecialSymbols(playerIGNAndServer[0]).toUpperCase();
-        server = swap.serverToEndPoint(playerIGNAndServer[1]);
+        server = SAwap.serverToEndPoint(playerIGNAndServer[1]);
 
         api.extractPlayerID(server, playerIGNAndServer, playerID => {
             if (playerID.toString().startsWith(`:warning:`))
@@ -86,10 +86,8 @@
         var fs = require(`fs`);
         var Input = require('./input.js');
         var input = new Input.Input();
-        var Swap = require('./swap.js');
-        var swap = new Swap.Swap();
         var racePath = `../data/race/${rankDesired.toLowerCase()}race.json`;
-        
+
         fs.readFile(racePath, `utf8`, function (err, raceJson) {
             if (err)
                 return post.message(`Cannot retrieve data because ${err}.`);
@@ -110,7 +108,7 @@
                     catch (err) {
                         return post.embed(`:warning: Error`, [[`___`, `Can't read ${updatedRaceJson.Participants[i].nickname}'s data. Try again in a few moments.`, false]]);
                     }
-                    participants += `\`\`${input.justifyToLeft(`#${parseInt(i) + 1}:`, 4)} ${rankCurrent.toUpperCase()} ${swap.romanToArabic(updatedRaceJson.Participants[i].division)} ` +
+                    participants += `\`\`${input.justifyToLeft(`#${parseInt(i) + 1}:`, 4)} ${rankCurrent.toUpperCase()} ${Swap.romanToArabic(updatedRaceJson.Participants[i].division)} ` +
                         `- ${LP } LP |\`\` ${updatedRaceJson.Participants[i].nickname}\n`;
                 };
                 for (i in updatedRaceJson.Winners) {
@@ -146,8 +144,6 @@
             return callback (raceJson);
     };
     race.assignRankPoints = function (raceJson, rankDesired, rankCurrent, rankLower, callback) {
-        var Swap = require('./swap.js');
-        var swap = new Swap.Swap();
         var API = require('./API.js');
         var api = new API.API();
 
@@ -155,7 +151,7 @@
 
         function raceLoop(i) {
             if (i < l) {
-                var server = swap.serverToEndPoint(raceJson.Participants[i].server);
+                var server = Swap.serverToEndPoint(raceJson.Participants[i].server);
                 var playerID = raceJson.Participants[i].id;
 
                 api.extractPlayerRanksData(server, playerID, rankJson => {
@@ -173,7 +169,7 @@
                         }
                     }
 
-                    if (i == l - 1) 
+                    if (i == l - 1)
                         callback(raceJson);
                     return raceLoop(i + 1);
                 });
@@ -182,9 +178,7 @@
         raceLoop(0);
     };
     race.calculatePlayerRacePoints = function (rankJson, rankDesired, rankCurrent, rankLower) {
-        var Swap = require('./swap.js');
-        var swap = new Swap.Swap();
-        var division = swap.romanToArabic(rankJson.rank)*100;
+        var division = Swap.romanToArabic(rankJson.rank)*100;
         var points = rankJson.leaguePoints;
         var racePoints = division - points;
 
@@ -234,7 +228,7 @@
                 return callback(updatedRaceJson);
             };
         };
-        updateLoop(0);        
+        updateLoop(0);
     };
     race.saveUpdateInFile = function (jsonToSave, racePath) {
         var fs = require(`fs`);
@@ -243,12 +237,12 @@
             delete jsonToSave.Participants[i].points;
             delete jsonToSave.Participants[i].division;
             delete jsonToSave.Participants[i].leaguePoints;
-        };  
+        };
         for (i in jsonToSave.Winners) {
             delete jsonToSave.Winners[i].points;
             delete jsonToSave.Winners[i].division;
             delete jsonToSave.Winners[i].leaguePoints;
-        }; 
+        };
         fs.writeFile(racePath, JSON.stringify(jsonToSave), err => {
             if (err) {
                 var d = new Date();

--- a/classes/race.js
+++ b/classes/race.js
@@ -1,4 +1,5 @@
 ﻿var Swap = require('./swap')
+var input = require('./input');
 
 exports.Race = function (data, post) {
     var race = this;
@@ -7,8 +8,6 @@ exports.Race = function (data, post) {
         var fs = require(`fs`);
         var Roles = require('./roles.js');
         var roles = new Roles.Roles(data.message.member);
-        var Input = require('./input.js');
-        var input = new Input.Input();
         var API = require('./API.js');
         var api = new API.API();
 
@@ -84,8 +83,6 @@ exports.Race = function (data, post) {
         post.message(`:hourglass_flowing_sand: Getting the ${rankDesired} race data. This might take a while...`);
 
         var fs = require(`fs`);
-        var Input = require('./input.js');
-        var input = new Input.Input();
         var racePath = `../data/race/${rankDesired.toLowerCase()}race.json`;
 
         fs.readFile(racePath, `utf8`, function (err, raceJson) {

--- a/classes/swap.js
+++ b/classes/swap.js
@@ -1,173 +1,139 @@
-﻿exports.Swap = function () {
-    var swap = this;
+﻿exports.serverToEndPoint = function(server) {
+  switch (server.toLowerCase()) {
+    case "br":
+      return "br1"
+    case "eune":
+      return "eun1"
+    case "euw":
+      return "euw1"
+    case "jp":
+      return "jp1"
+    case "kr":
+      return "kr"
+    case "lan":
+      return "la1"
+    case "las":
+      return "la2"
+    case "na":
+      return "na1"
+    case "oce":
+      return "oc1"
+    case "tr":
+      return "tr1"
+    case "ru":
+      return "ru"
+    case "pbe":
+      return "pbe1"
+    default:
+      return 0
+  }
+}
 
-    swap.serverToEndPoint = function (server) {
-        switch (server.toLowerCase()) {
-            case "br":
-                return "br1";
-            case "eune":
-                return "eun1";
-            case "euw":
-                return "euw1";
-            case "jp":
-                return "jp1";
-            case "kr":
-                return "kr";
-            case "lan":
-                return "la1";
-            case "las":
-                return "la2";
-            case "na":
-                return "na1";
-            case "oce":
-                return "oc1";
-            case "tr":
-                return "tr1";
-            case "ru":
-                return "ru";
-            case "pbe":
-                return "pbe1";
-            default: return 0;
-        }
-    };
-    swap.endPointToServer = function (endPoint) {
-        switch (endPoint.toLowerCase()) {
-            case "br1":
-                return "br";
-            case "eun1":
-                return "eune";
-            case "euw1":
-                return "euw";
-            case "jp1":
-                return "jp";
-            case "kr":
-                return "kr";
-            case "la1":
-                return "lan";
-            case "la2":
-                return "las";
-            case "na1":
-                return "na";
-            case "oc1":
-                return "oce";
-            case "tr1":
-                return "tr";
-            case "ru":
-                return "ru";
-            case "pbe1":
-                return "pbe";
-            default: return 0;
-        }
-    };
-    swap.spellIDToSpellIcon = function (spellID) {
-        switch (spellID) {
-            case 1:
-                return `<:Cleanse:315829639941455872>`; 
-            case 13:
-                return `<:Clarity:315829639400652801>`;
-            case 21: 
-                return `<:Barrier:315829639589265408>`;
-            case 7:
-                return `<:Heal:315829640537047040>`;
-            case 14:
-                return `<:Ignite:315829640641904650>`;
-            case 4:
-                return `<:Flash:315829640302166016>`; 
-            case 12: 
-                return `<:Teleport:315829641057402880>`;
-            case 32:
-                return `<:Mark:315829640784510976>`;
-            case 11:
-                return `<:Smite:315829640583315457>`;
-            case 6:
-                return `<:Ghost:315829640340176896>`;
-            case 3:
-                return `<:Exhaust:315829639652179970>`;
-            default: return `❓`;
-        }
-    };
-    swap.gameModeIDToName = function (gameModeID) {
-        switch (gameModeID) {
-            case 0:
-                return " - Custom game";
-            case 8:
-                return " - Normal Twisted Treeline";
-            case 2:
-                return " - Normal Blind Pick 5v5";
-            case 14:
-                return " - Normal Draft Pick 5v5";
-            case 4:
-                return " - Ranked Solo 5v5";
-            case 42:
-                return " - Ranked Team 5v5";
-            case 31:
-                return " - Coop vs AI Intro Bots";
-            case 32:
-                return " - Coop vs AI Beginner Bots";
-            case 33:
-                return " - Coop vs AI Intermediate Bots";
-            case 400:
-                return " - Normal Draft Pick 5v5";
-            case 410:
-                return " - Ranked Draft Pick 5v5";
-            case 420:
-                return " - Ranked Solo/Duo 5v5";
-            case 440:
-                return " - Ranked Flex 5v5";
-            case 52:
-                return " - Coop vs AI Twisted Treeline";
-            default: return "";
-        }
-    };
-    swap.romanToArabic = function (number) {
-        if (number == "I")
-            return 1;
-        else if (number == "II")
-            return 2;
-        else if (number == "III")
-            return 3;
-        else if (number == "IV")
-            return 4;
-        else if (number == "V")
-            return 5;
-        else return 0;
-    };
-    swap.arabicToRoman = function (number) {
-        if (number == 1)
-            return `I`;
-        else if (number == 2)
-            return `II`;
-        else if (number == 3)
-            return `III`;
-        else if (number == 4)
-            return `IV`;
-        else if (number == 5)
-            return `V`;
-        else return 0;
-    };
-    swap.numberToNumberEmoji = function (number) {
-        switch (number) {
-            case 1:
-                return ":one:";
-            case 2:
-                return ":two:";
-            case 3:
-                return ":three:";
-            case 4:
-                return ":four:";
-            case 5:
-                return ":five:";
-            case 6:
-                return ":six:";
-            case 7:
-                return ":seven:";
-            case 8:
-                return ":eight:";
-            case 9:
-                return ":nine:";
-            case 0:
-                return ":zero:";
-            default: return "?";
-        }
-    };
-};
+exports.spellIDToSpellIcon = function(spellID) {
+  switch (spellID) {
+    case 1:
+      return `<:Cleanse:315829639941455872>`
+    case 13:
+      return `<:Clarity:315829639400652801>`
+    case 21:
+      return `<:Barrier:315829639589265408>`
+    case 7:
+      return `<:Heal:315829640537047040>`
+    case 14:
+      return `<:Ignite:315829640641904650>`
+    case 4:
+      return `<:Flash:315829640302166016>`
+    case 12:
+      return `<:Teleport:315829641057402880>`
+    case 32:
+      return `<:Mark:315829640784510976>`
+    case 11:
+      return `<:Smite:315829640583315457>`
+    case 6:
+      return `<:Ghost:315829640340176896>`
+    case 3:
+      return `<:Exhaust:315829639652179970>`
+    default:
+      return `❓`
+  }
+}
+
+exports.gameModeIDToName = function(gameModeID) {
+  switch (gameModeID) {
+    case 0:
+      return " - Custom game"
+    case 8:
+      return " - Normal Twisted Treeline"
+    case 2:
+      return " - Normal Blind Pick 5v5"
+    case 14:
+      return " - Normal Draft Pick 5v5"
+    case 4:
+      return " - Ranked Solo 5v5"
+    case 42:
+      return " - Ranked Team 5v5"
+    case 31:
+      return " - Coop vs AI Intro Bots"
+    case 32:
+      return " - Coop vs AI Beginner Bots"
+    case 33:
+      return " - Coop vs AI Intermediate Bots"
+    case 400:
+      return " - Normal Draft Pick 5v5"
+    case 410:
+      return " - Ranked Draft Pick 5v5"
+    case 420:
+      return " - Ranked Solo/Duo 5v5"
+    case 440:
+      return " - Ranked Flex 5v5"
+    case 52:
+      return " - Coop vs AI Twisted Treeline"
+    default:
+      return ""
+  }
+}
+
+exports.romanToArabic = function(number) {
+  if (number == "I") return 1
+  else if (number == "II") return 2
+  else if (number == "III") return 3
+  else if (number == "IV") return 4
+  else if (number == "V") return 5
+  else return 0
+}
+
+exports.arabicToRoman = function(number) {
+  if (number == 1) return `I`
+  else if (number == 2) return `II`
+  else if (number == 3) return `III`
+  else if (number == 4) return `IV`
+  else if (number == 5) return `V`
+  else return 0
+}
+
+exports.numberToNumberEmoji = function(number) {
+  switch (number) {
+    case 1:
+      return ":one:"
+    case 2:
+      return ":two:"
+    case 3:
+      return ":three:"
+    case 4:
+      return ":four:"
+    case 5:
+      return ":five:"
+    case 6:
+      return ":six:"
+    case 7:
+      return ":seven:"
+    case 8:
+      return ":eight:"
+    case 9:
+      return ":nine:"
+    case 0:
+      return ":zero:"
+    default:
+      return "?"
+  }
+}

--- a/classes/usermessage.js
+++ b/classes/usermessage.js
@@ -1,5 +1,3 @@
-var input = require('./input');
-
 exports.UserMessage = function (data) {
     var userMessage = this;
 
@@ -17,11 +15,7 @@ exports.UserMessage = function (data) {
             return true;
         return false;
     };
-    userMessage.hasKeywordTrigger = function () {
-        if (input.findKeywords())
-            return true;
-        return false;
-    };
+
     userMessage.hasDearViktorTrigger = function () {
         if ((userMessage.content.toLowerCase()).startsWith('dear viktor'))
             return true;

--- a/classes/usermessage.js
+++ b/classes/usermessage.js
@@ -1,8 +1,7 @@
-var Input = require('./input.js');
+var input = require('./input');
 
 exports.UserMessage = function (data) {
     var userMessage = this;
-    var input = new Input.Input();
 
     userMessage.content = data.message.content;
     userMessage.authorName = data.message.author.username;


### PR DESCRIPTION
- `Swap`, `API` and `Input` are all static modules now. There's no need to instantiate them with `new`. This makes sense since none of these modules/classes keep state so there's no reason for them to be a class (whose primary purpose is to keep state).

- `API`, `Input` and `Swap` are now only required once per document in the conventional place of being at the top of the document. This makes no real difference other than aesthetics and reducing confusion, since in Node, requiring the same module twice has no performance impact (any subsequent calls to `require()` for the same module are cached). This would be more important if using ES6 modules, though, as in ES6 modules may only be from the top level of the file (or using `import()`).

- `API.extractFromURL(url, cb)` now uses the typical Node-style callback convention: The first argument will be an error object (in this case, an error message) or a undefined. If the error is undefined then the second argument will be the result of the operation. This eliminates the need for `API.everythingOkay(object)`, so this has been removed.

- `UserMessage.hasKeywordTrigger()` has been removed because it was not used and, had it been used, it would have resulted in a runtime error because `Input.findKeywords()` does not exist.

- `API.extractFromURL(url, cb)` refers to a module function called `extractFromUrl`, which now allows the user to specify headers as an object. These headers will be appended to the request.

- `API.makeRiotRequest(server, path, cb)` was added, which will, given a `path`, construct the appropriate url to send a request to the Riot API servers and execute the request. It will append the Riot API key as the `x-riot-token` header to the request, which is the other method that the Riot API accepts api keys to be specified. This prevents having to specify the api key in every single definition of the url.
