### PR TITLE
Remove the use of compilerOptions.paths

### DIFF
--- a/lib/commands/commands/fun.ts
+++ b/lib/commands/commands/fun.ts
@@ -9,13 +9,13 @@ import { log } from '../../log';
 import BotGraph from '../../graphs';
 import { findOption } from '../../storage/db';
 import { COLORS } from '@modules/colors';
-// @ts-ignore:next-line
-import { CAT_API_TOKEN } from '@config/config.json';
+import * as Config from '../../config';
 
 export const meow = async (msg: Discord.Message): Promise<void> => {
 	msg.channel.startTyping();
+	const token = Config.get('CAT_API_TOKEN');
 	const cat: void | AxiosResponse = await axios(
-		`https://api.thecatapi.com/v1/images/search?api_key=${CAT_API_TOKEN}`,
+		`https://api.thecatapi.com/v1/images/search?api_key=${token}`,
 	).catch(() => {
 		msg.channel.send('Unable to get a cat.');
 		msg.channel.stopTyping();

--- a/lib/commands/commands/fun.ts
+++ b/lib/commands/commands/fun.ts
@@ -8,7 +8,7 @@ import { chooseRandom } from '../../rng';
 import { log } from '../../log';
 import BotGraph from '../../graphs';
 import { findOption } from '../../storage/db';
-import { COLORS } from '@modules/colors';
+import { COLORS } from '../../modules/colors';
 import * as Config from '../../config';
 
 export const meow = async (msg: Discord.Message): Promise<void> => {

--- a/lib/commands/commands/profiles.ts
+++ b/lib/commands/commands/profiles.ts
@@ -25,7 +25,7 @@ import {
 import { getSummonerId, getPlatform, getHost } from './riot';
 import { client, getSummonerBySummonerId } from '../../riot';
 import { isBotUser } from '../../bot';
-import { COLORS } from '@modules/colors';
+import { COLORS } from '../../modules/colors';
 import * as Config from '../../config';
 const RIOT_API_TOKEN = Config.get('RIOT_API_TOKEN');
 

--- a/lib/commands/commands/profiles.ts
+++ b/lib/commands/commands/profiles.ts
@@ -26,8 +26,8 @@ import { getSummonerId, getPlatform, getHost } from './riot';
 import { client, getSummonerBySummonerId } from '../../riot';
 import { isBotUser } from '../../bot';
 import { COLORS } from '@modules/colors';
-// @ts-ignore:next-line
-import { RIOT_API_TOKEN } from '@config/config.json';
+import * as Config from '../../config';
+const RIOT_API_TOKEN = Config.get('RIOT_API_TOKEN');
 
 const timeout = 900000;
 

--- a/lib/commands/commands/riot.ts
+++ b/lib/commands/commands/riot.ts
@@ -27,7 +27,7 @@ import {
 	getSummonerByAccountId,
 } from '../../riot';
 import { format as sprintf } from 'util';
-import { COLORS } from '@modules/colors';
+import { COLORS } from '../../modules/colors';
 
 export const getPlatform = async (server?: string): Promise<string> => {
 	const { platform } = await findServerByName(server);

--- a/lib/commands/logic.ts
+++ b/lib/commands/logic.ts
@@ -9,7 +9,7 @@ import {
 import { botRefuses } from '../rng';
 import { isUserAdmin } from '../message';
 import { replaceAll } from '../helpers';
-import { COLORS } from '@modules/colors';
+import { COLORS } from '../modules/colors';
 
 class Command {
 	public channel: Discord.TextChannel | Discord.DMChannel | Discord.NewsChannel;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+import path from 'path';
+import fs from 'fs';
+
+let config: Options;
+
+interface Options {
+	DISCORD_TOKEN: string;
+	RIOT_API_TOKEN: string;
+	CAT_API_TOKEN: string;
+	DATABASE_URL: string;
+}
+
+export function load(): void {
+	if (config !== undefined) {
+		return;
+	}
+
+	const location = path.resolve(process.cwd(), 'config.json');
+	const file = fs.readFileSync(location, 'utf8');
+	config = JSON.parse(file);
+}
+
+export function get<K extends keyof Options>(name: K): Options[K] {
+	load();
+
+	const value = config[name];
+	assert.notStrictEqual(value, undefined, `"${name}" not present in config`);
+	return value;
+}

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -11,7 +11,7 @@ import {
 } from './storage/db';
 import { createEmbed, toDDHHMMSS, removeKeyword, replaceAll } from './helpers';
 import { findTextChannel } from './bot';
-import { COLORS } from '@modules/colors';
+import { COLORS } from './modules/colors';
 
 type LogRoom = 'roomLogMsgs' | 'roomLogUsers';
 

--- a/lib/graphs.ts
+++ b/lib/graphs.ts
@@ -3,7 +3,7 @@ import sharp from 'sharp';
 import * as d3 from 'd3';
 import _ from 'lodash';
 import { MessageAttachment } from 'discord.js';
-import { COLORS } from '@modules/colors';
+import { COLORS } from './modules/colors';
 
 type TGraphSize = {
 	width: number;

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -2,7 +2,7 @@ import Discord from 'discord.js';
 import moment from 'moment';
 import { IEmbedField } from './types/command';
 import { findOption } from './storage/db';
-import { COLORS } from '@modules/colors';
+import { COLORS } from './modules/colors';
 
 export const getCommandSymbol = async (): Promise<string | undefined> =>
 	await findOption('commandSymbol');

--- a/lib/riot.ts
+++ b/lib/riot.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { format as sprintf } from 'util';
 import { Request, default as fetch } from 'node-fetch';
-// @ts-ignore:next-line
-import { RIOT_API_TOKEN } from '@config/config.json';
+import * as Config from './config';
 
 export class RiotClient {
 	#token: string;
@@ -40,7 +39,7 @@ export class RiotClient {
 	}
 }
 
-export const client = new RiotClient(RIOT_API_TOKEN);
+export const client = new RiotClient(Config.get('RIOT_API_TOKEN'));
 
 interface Response<T> {
 	data: T;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "viktorbot",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1756,11 +1756,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
-    },
-    "module-alias": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
-      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
     "moment": {
       "version": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"discord.js": "^12.2.0",
 		"emoji-regex": "^8.0.0",
 		"jsdom": "^16.1.0",
-		"module-alias": "^2.2.2",
 		"moment": "^2.24.0",
 		"mongodb": "^3.5.9",
 		"node-fetch": "^2.6.0",
@@ -47,9 +46,5 @@
 		"@typescript-eslint/parser": "^3.7.1",
 		"eslint": "^7.5.0",
 		"typescript": "^3.9.7"
-	},
-	"_moduleAliases": {
-		"@modules": "dist/lib/modules",
-		"@config": "dist/config"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,12 +16,7 @@
 		"esModuleInterop": true,
 		"allowUnreachableCode": false,
 		"allowUnusedLabels": true,
-		"pretty": true,
-		"paths": {
-			"@modules/*": ["lib/modules/*"],
-			"@config/*": ["config/*"],
-			"config.json": ["./config.example.json"]
-		}
+		"pretty": true
 	},
 	"include": ["./**/*"],
 	"exclude": ["node_modules", "dist", "config.json"]

--- a/viktor.ts
+++ b/viktor.ts
@@ -1,14 +1,13 @@
-require('module-alias/register');
 import { connectToDb } from './lib/storage/db';
 import { initialize } from './lib/bot';
 import { log } from './lib/log';
-
-// @ts-ignore:next-line
-import { DATABASE_URL, DISCORD_TOKEN } from '@config/config.json';
+import * as Config from './lib/config';
 
 async function main() {
-	await connectToDb(DATABASE_URL);
-	await initialize(DISCORD_TOKEN);
+	const dbUrl = Config.get('DATABASE_URL');
+	const discordToken = Config.get('DISCORD_TOKEN');
+	await connectToDb(dbUrl);
+	await initialize(discordToken);
 }
 
 main().catch(error => log.WARN(error));


### PR DESCRIPTION
`compilerOptions.paths` is an option in TypeScript that enables one to turn paths like these

    import foo from "@modules/foo";

into these

    import foo from "../../.../foo";

Unfortunately, TypeScript itself does not resolve these paths on its own, it simply allows for typeck to succeed if using module aliases in other bundlers like Webpack. As ViktorBot does not use Webpack, a runtime module has been included - module-alias - to enable resolution of the faux paths at runtime.

Unfortunately, this breaks testing, as it means that the only way to test any file is to ensure that `module-alias` has been loaded.

In order to add unit tests to this project, I'm creating this PR so we can revert to not relying on special hooks so that files can be loaded in isolation.